### PR TITLE
cuda 11.1 + ubuntu 20.04 with newest cmake

### DIFF
--- a/Dockerfile-GPU&CPU-ubun20
+++ b/Dockerfile-GPU&CPU-ubun20
@@ -1,0 +1,65 @@
+# Base Layer
+# Due to depreciation of 11.4.0, we must use 11.3.1.
+FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
+
+# 如果你在中国，将镜像站提供的sources.list保存到dockerfile同目录下，使用apt镜像仓库以加快下载/节省流量。
+# COPY ./sources.list /etc/apt/sources.list
+
+# Package Downloads
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    python3-dev python3-pip python3-setuptools git g++ wget make libprotobuf-dev protobuf-compiler libopencv-dev \
+    libgoogle-glog-dev libboost-all-dev libhdf5-dev libatlas-base-dev ffmpeg
+
+# Python Dependancies
+RUN pip3 install --upgrade pip
+# RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3 install numpy opencv-python 
+
+# Replace CMake with a CUDA-compatible version: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
+RUN wget --progress=bar https://github.com/Kitware/CMake/releases/download/v3.29.5/cmake-3.29.5-linux-x86_64.tar.gz && \
+    tar xzf cmake-3.29.5-linux-x86_64.tar.gz -C /opt && \
+    rm cmake-3.29.5-linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.29.5-linux-x86_64/bin:$PATH"
+
+# Grab OpenPose
+ENV OPENPOSE_DIR="/home/openpose"
+WORKDIR $OPENPOSE_DIR
+RUN git clone https://github.com/CMU-Perceptual-Computing-Lab/openpose.git .
+RUN sed -i 's/sudo //g' $OPENPOSE_DIR/scripts/ubuntu/install_deps.sh && bash $OPENPOSE_DIR/scripts/ubuntu/install_deps.sh
+
+# Download Models
+RUN cd $OPENPOSE_DIR/models/pose/body_25 && wget --progress=bar -O pose_iter_584000.caffemodel -c https://www.dropbox.com/s/3x0xambj2rkyrap/pose_iter_584000.caffemodel?dl=0
+RUN cd $OPENPOSE_DIR/models/face && wget --progress=bar -O pose_iter_116000.caffemodel -c https://www.dropbox.com/s/d08srojpvwnk252/pose_iter_116000.caffemodel?dl=0
+RUN cd $OPENPOSE_DIR/models/hand && wget --progress=bar -O pose_iter_102000.caffemodel -c https://www.dropbox.com/s/gqgsme6sgoo0zxf/pose_iter_102000.caffemodel?dl=0
+
+# Remove Download Capabilities from OpenPose
+RUN sed -i 's/executeShInItsFolder "getModels.sh"/# executeShInItsFolder "getModels.sh"/g' $OPENPOSE_DIR/scripts/ubuntu/install_openpose_JetsonTX2_JetPack3.1.sh
+RUN sed -i 's/executeShInItsFolder "getModels.sh"/# executeShInItsFolder "getModels.sh"/g' $OPENPOSE_DIR/scripts/ubuntu/install_openpose_JetsonTX2_JetPack3.3.sh
+RUN sed -i 's/download_model("BODY_25"/# download_model("BODY_25"/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/78287B57CF85FA89C03F1393D368E5B7/# 78287B57CF85FA89C03F1393D368E5B7/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/download_model("body (COCO)"/# download_model("body (COCO)"/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/5156d31f670511fce9b4e28b403f2939/# 5156d31f670511fce9b4e28b403f2939/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/download_model("body (MPI)"/# download_model("body (MPI)"/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/2ca0990c7562bd7ae03f3f54afa96e00/# 2ca0990c7562bd7ae03f3f54afa96e00/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/download_model("face"/# download_model("face"/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/e747180d728fa4e4418c465828384333/# e747180d728fa4e4418c465828384333/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/download_model("hand"/# download_model("hand"/g' $OPENPOSE_DIR/CMakeLists.txt
+RUN sed -i 's/a82cfc3fea7c62f159e11bd3674c1531/# a82cfc3fea7c62f159e11bd3674c1531/g' $OPENPOSE_DIR/CMakeLists.txt
+
+# Build OpenPose
+WORKDIR $OPENPOSE_DIR/gpu_build
+RUN cmake -DBUILD_PYTHON=ON .. && make -j `nproc`
+WORKDIR $OPENPOSE_DIR/cpu_build
+RUN cmake -DBUILD_PYTHON=ON -DGPU_MODE=CPU_ONLY -DOWNLOAD_HAND_MODEL=OFF -DOWNLOAD_FACE_MODEL=OFF .. && make -j `nproc`
+
+# clean apt
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR $OPENPOSE_DIR
+
+LABEL maintainer="hiibolt, AClon"
+LABEL version="0.1"
+LABEL description="OpenPose Docker Image, built on CUDA 11.1.1, cuDNN 8, and Ubuntu 20.04. Built files are in `openpose/gpu_build` and `openpose/cpu_build`. Use CUDA 11.1 for Easymocap."
+LABEL url="https://github.com/igait-niu/igait-openpose/blob/main/Dockerfile"
+LABEL image_size="13.09 GB"


### PR DESCRIPTION
improves:
1. use newest cmake, change `cmake-3.29.5-Linux-x86_64.tar.gz` to `cmake-3.29.5-linux-x86_64.tar.gz`
2. `${PATH}` to `$PATH` according to this: https://stackoverflow.com/a/65119275/19986873
3. image built `openpose/cpu_build` and `openpose/gpu_build` for the same time. Because my 4GB vram gpu always failed running workload test.
4. replace `sudo` in `openpose/scripts/ubuntu/install_deps.sh` because not installed `sudo`
5. new ENV `OPENPOSE_DIR` to dedicate the path that user want.
6. Optional apt mirror repo for speed up download.

test success on my pc:
<details><summary> docker build -t openpose_ubun20_cu11-1 . --no-cache </summary>
<p>

```
[ 93%] Building CXX object src/openpose/producer/CMakeFiles/openpose_producer.dir/webcamReader.cpp.o
[ 93%] Built target 18_synchronous_custom_all_and_datum.bin
[ 93%] Linking CXX shared library libopenpose_net.so
[ 93%] Built target openpose_net
[ 94%] Linking CXX shared library libopenpose_tracking.so
[ 94%] Built target openpose_tracking
[ 94%] Linking CXX shared library libopenpose_producer.so
[ 94%] Built target openpose_producer
[ 95%] Building CXX object src/openpose/utilities/CMakeFiles/openpose_utilities.dir/fileSystem.cpp.o
[ 95%] Building CXX object src/openpose/utilities/CMakeFiles/openpose_utilities.dir/flagsToOpenPose.cpp.o
[ 95%] Building CXX object src/openpose/utilities/CMakeFiles/openpose_utilities.dir/errorAndLog.cpp.o
[ 96%] Building CXX object src/openpose/utilities/CMakeFiles/openpose_utilities.dir/keypoint.cpp.o
[ 96%] Building CXX object src/openpose/utilities/CMakeFiles/openpose_utilities.dir/openCv.cpp.o
[ 96%] Building CXX object src/openpose/utilities/CMakeFiles/openpose_utilities.dir/openCvPrivate.cpp.o
[ 97%] Building CXX object src/openpose/utilities/CMakeFiles/openpose_utilities.dir/string.cpp.o
[ 97%] Building CXX object src/openpose/utilities/CMakeFiles/openpose_utilities.dir/profiler.cpp.o
[ 97%] Linking CXX shared library libopenpose_utilities.so
[ 97%] Built target openpose_utilities
[ 98%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/defineTemplates.cpp.o
[ 98%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/wrapperStructExtra.cpp.o
[ 98%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/wrapperAuxiliary.cpp.o
[ 98%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/wrapperStructFace.cpp.o
[ 99%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/wrapperStructGui.cpp.o
[ 99%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/wrapperStructHand.cpp.o
[100%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/wrapperStructOutput.cpp.o
[ 99%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/wrapperStructInput.cpp.o
[100%] Building CXX object src/openpose/wrapper/CMakeFiles/openpose_wrapper.dir/wrapperStructPose.cpp.o
[100%] Linking CXX shared library libopenpose_wrapper.so
[100%] Built target openpose_wrapper
Built target openpose_lib
--> 7291eb4df34a
STEP 31/36: RUN apt-get clean && rm -rf /var/lib/apt/lists/*
--> 67b90ad1a90f
STEP 32/36: WORKDIR $OPENPOSE_DIR
--> e6f8d8808f0b
STEP 33/36: LABEL maintainer="hiibolt, AClon"
--> 6a2ff0d892c7
STEP 34/36: LABEL version="0.1"
--> 1c941bd19623
STEP 35/36: LABEL description="OpenPose Docker Image, built on CUDA 11.1.1, cuDNN 8, and Ubuntu 20.04."
--> eba8905bf10c
STEP 36/36: LABEL url="https://github.com/igait-niu/igait-openpose/blob/main/Dockerfile"
COMMIT openpose_ubun20_cu11-1
--> 73c31f738723
Successfully tagged localhost/openpose_ubun20_cu11-1:latest
73c31f7387237d473e1bd50f7db27986a5efc0ba95d845856387670665e5f54e
```

</p>
</details> 

<details><summary>image test</summary>
<p>

```
root@em:/home/openpose# OUT_PATH=/home/em/out
root@em:/home/openpose# ./cpu_build/examples/openpose/openpose.bin --image_dir examples/media/ --display 0 --write_images $OUT_PATH --write_json $
OUT_PATH --model_pose COCO --net_resolution -1x240            
Starting OpenPose demo...
Configuring OpenPose...
Starting thread(s)...
---------------------------------- WARNING ----------------------------------
We have introduced an additional boost in accuracy in the CUDA version of about 0.2% with respect to the CPU/OpenCL versions. We will not port this to CPU given the considerable slow down in speed it would add to it. Nevertheless, this accuracy boost is almost insignificant so the CPU/OpenCL versions can be safely used.
-------------------------------- END WARNING --------------------------------
OpenPose demo successfully finished. Total time: 100.407789 seconds.


root@em:/home/openpose# ./gpu_build/examples/openpose/openpose.bin --image_dir examples/media/ --display 0 --write_images $OUT_PATH --write_json $
OUT_PATH --model_pose COCO --net_resolution -1x240
Starting OpenPose demo...
Configuring OpenPose...
Starting thread(s)...
Auto-detecting all available GPUs... Detected 1 GPU(s), using 1 of them starting at GPU 0.
F0611 09:07:37.184743  3892 cudnn_conv_layer.cpp:53] Check failed: status == CUDNN_STATUS_SUCCESS (1 vs. 0)  CUDNN_STATUS_NOT_INITIALIZED
*** Check failure stack trace: ***
    @     0x7b9fba00d1c3  google::LogMessage::Fail()
    @     0x7b9fba01225b  google::LogMessage::SendToLog()
    @     0x7b9fba00cebf  google::LogMessage::Flush()
    @     0x7b9fba00d6ef  google::LogMessageFatal::~LogMessageFatal()
    @     0x7b9fb8e06115  caffe::CuDNNConvolutionLayer<>::LayerSetUp()
    @     0x7b9fb8eeae8d  caffe::Net<>::Init()
    @     0x7b9fb8eed3a5  caffe::Net<>::Net()
    @     0x7b9fba6922bc  op::NetCaffe::initializationOnThread()
    @     0x7b9fba6abdfd  op::addCaffeNetOnThread()
    @     0x7b9fba6acff5  op::PoseExtractorCaffe::netInitializationOnThread()
    @     0x7b9fba6b1915  op::PoseExtractorNet::initializationOnThread()
    @     0x7b9fba6a97e7  op::PoseExtractor::initializationOnThread()
    @     0x7b9fba6a5087  op::WPoseExtractor<>::initializationOnThread()
    @     0x7b9fba6d7cf7  op::Worker<>::initializationOnThreadNoException()
    @     0x7b9fba6d7e48  op::SubThread<>::initializationOnThread()
    @     0x7b9fba6d9650  op::Thread<>::initializationOnThread()
    @     0x7b9fba6dcb4c  op::Thread<>::threadFunction()
    @     0x7b9fba328df4  (unknown)
    @     0x7b9fb8c38609  start_thread
    @     0x7b9fba164133  clone
Aborted (core dumped)
```

</p>
</details> 

- The reason why to build both `cpu_build` and `gpu_build` is that currently I can only use `cpu_build`. When use `gpu_build` with args `--num_gpu=0`, although running test workload success, but no pose detected.
- downgrade CUDA 11.1 to fit env for this: https://github.com/zju3dv/EasyMocap